### PR TITLE
Bug 923232 - Update node-newrelic to v0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "habitat": "0.4.2",
     "less-middleware": "0.1.12",
     "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.6",
-    "newrelic": "0.9.22",
+    "newrelic": "0.11.4",
     "nunjucks": "0.1.10",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.2.tar.gz"
   },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=923232
