### PR TITLE
Bug 966029 - Use the MakeAPI's protectedSearch path so unpublished makes...

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -11,6 +11,10 @@ export OPTIMIZE_CSS=false
 # The Make API endpoint
 export MAKE_ENDPOINT=http://localhost:5000
 
+# Make API Keys
+export MAKE_PUBLIC_KEY=00000000-0000-0000-000000000000
+export MAKE_PRIVATE_KEY=00000000-0000-0000-000000000000
+
 # Location of the webmaker.org server
 export WEBMAKERORG=http://localhost:7777
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "helmet": "0.1.2",
     "hood": "0.2.1",
     "less-middleware": "0.1.12",
-    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.16",
+    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.17",
     "messina": "0.1.1",
     "newrelic": "1.2.0",
     "nunjucks": "0.1.10",

--- a/server.js
+++ b/server.js
@@ -23,7 +23,12 @@ var app = express(),
     env = new Habitat(),
     profileHandlerFn,
     makeAPIClient = new Makeapi({
-      apiURL: env.get("MAKE_ENDPOINT")
+      apiURL: env.get("MAKE_ENDPOINT"),
+      hawk: {
+        id: env.get("MAKE_PUBLIC_KEY"),
+        key: env.get("MAKE_PRIVATE_KEY"),
+        algorithm: "sha256"
+      }
     }),
     nunjucksEnv = new nunjucks.Environment( new nunjucks.FileSystemLoader( path.join( __dirname, 'views' )), {
       autoescape: true


### PR DESCRIPTION
... can still be previewed

https://bugzilla.mozilla.org/show_bug.cgi?id=966029
