### PR TITLE
bug975126 - Update webmaker-i18n to v0.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nunjucks": "0.1.10",
     "webmaker-download-locales": "0.1.0",
     "webmaker-locale-mapping": "latest",
-    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.2.tar.gz"
+    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.11.tar.gz"
   },
   "devDependencies": {
     "bower": "1.2.7"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=975126
