### PR TITLE
Changing version of webmaker-download-locales to resolve Heroku issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "newrelic": "1.5.5",
     "nunjucks": "0.1.10",
     "url-template": "^2.0.4",
-    "webmaker-download-locales": "0.1.2",
+    "webmaker-download-locales": "0.2.5",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.11.tar.gz",
     "webmaker-locale-mapping": "0.0.5",
     "webmaker-translation-stats": "0.0.1"


### PR DESCRIPTION
Same as https://github.com/mozilla/popcorn.webmaker.org/pull/615
